### PR TITLE
Dispatch change event on parent if address updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add a event listener on the [postcode and housenumber fields](https://github.com
         name="{{ $type }}_postcode"
         label="Postcode"
         v-model.lazy="checkout.{{ $type }}_address.postcode"
-+       v-on:change="$root.$nextTick(() => window.$emit('postcode-change', checkout.{{ $type }}_address))"
++       v-on:change="(event) => $root.$nextTick(() => window.$emit('postcode-change', event))"
         required
     />
 

--- a/resources/js/package.js
+++ b/resources/js/package.js
@@ -14,7 +14,7 @@ const getAddressFromExperiusPostcode = useMemoize(
     }
 )
 
-async function updateAddressFromExperiusPostcode(address) {
+async function updateAddressFromExperiusPostcode(address, event) {
     if ((address?.country_id || address?.country_code) != 'NL') {
         return
     }
@@ -35,6 +35,7 @@ async function updateAddressFromExperiusPostcode(address) {
 
     address.city = response.data.postcode.city
     address.street[0] = response.data.postcode.street
+    event?.target?.parentElement?.dispatchEvent?.(new Event('change', {bubbles: true}));
 }
 
 on('postcode-change', useDebounceFn(updateAddressFromExperiusPostcode, 100), { autoremove: false });


### PR DESCRIPTION
Based on the changes in rapidez/core#1244
This change will not cause breakages if the event is not passed.

It will trigger a bubbling change event, meaning it will trigger a graphql mutation in the checkout
https://github.com/rapidez/core/blob/6fd078f0763ba9800e2a97edc1716f0f7753b0d8/resources/views/checkout/steps/shipping-address.blade.php#L19